### PR TITLE
Create2 support with respective test

### DIFF
--- a/src/Options.sol
+++ b/src/Options.sol
@@ -66,6 +66,11 @@ struct Options {
      * Options for OpenZeppelin Defender deployments.
      */
     DefenderOptions defender;
+
+    /*
+    * When set, uses CREATE2 for deployment with the provided salt.
+    */
+    bytes32 customSalt;
 }
 
 /**

--- a/src/internal/Core.sol
+++ b/src/internal/Core.sol
@@ -423,7 +423,7 @@ library Core {
         return inputs;
     }
 
-    // subvisual change: originally `deploy` ignore options when it's not using DefenderDeploy. Since `salt` is defined there, we'll explicity pass the salt option to a new function `_deploy`
+    // subvisual change: added customSalt parameter to Options struct and use it to determine whether to deploy with CREATE2
     function deploy(
         string memory contractName,
         bytes memory constructorData,
@@ -432,7 +432,7 @@ library Core {
         if (opts.defender.useDefenderDeploy) {
             return DefenderDeploy.deploy(contractName, constructorData, opts.defender);
         } else {
-            if (opts.defender.salt != 0) {
+            if (opts.customSalt != 0) {
                 return _deployWithCreate2(contractName, constructorData, opts.defender.salt);
             } else {
                 return _deploy(contractName, constructorData);

--- a/src/internal/Core.sol
+++ b/src/internal/Core.sol
@@ -423,6 +423,7 @@ library Core {
         return inputs;
     }
 
+    // subvisual change: originally `deploy` ignore options when it's not using DefenderDeploy. Since `salt` is defined there, we'll explicity pass the salt option to a new function `_deploy`
     function deploy(
         string memory contractName,
         bytes memory constructorData,
@@ -431,8 +432,37 @@ library Core {
         if (opts.defender.useDefenderDeploy) {
             return DefenderDeploy.deploy(contractName, constructorData, opts.defender);
         } else {
-            return _deploy(contractName, constructorData);
+            if (opts.defender.salt != 0) {
+                return _deployWithCreate2(contractName, constructorData, opts.defender.salt);
+            } else {
+                return _deploy(contractName, constructorData);
+            }
         }
+    }
+
+    function _deployWithCreate2(string memory contractName, bytes memory constructorData, bytes32 salt) private returns (address) {
+        bytes memory creationCode = Vm(Utils.CHEATCODE_ADDRESS).getCode(contractName);
+        address deployedAddress = _deployFromBytecodeWithCreate2(abi.encodePacked(creationCode, constructorData), uint256(salt));
+        if (deployedAddress == address(0)) {
+            revert(
+                string.concat(
+                    "Failed to deploy contract ",
+                    contractName,
+                    ' using constructor data "',
+                    string(constructorData),
+                    '"'
+                )
+            );
+        }
+        return deployedAddress;
+    }
+
+    function _deployFromBytecodeWithCreate2(bytes memory bytecode, uint256 salt) private returns (address) {
+        address addr;
+        assembly {
+            addr := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+        return addr;
     }
 
     function _deploy(string memory contractName, bytes memory constructorData) private returns (address) {

--- a/test/Upgrades.t.sol
+++ b/test/Upgrades.t.sol
@@ -53,7 +53,7 @@ contract UpgradesTest is Test {
 
     function testDeterministicUUPS() public {
         Options memory opts;
-        opts.defender.salt = 0xabc0000000000000000000000000000000000000000000000000000000000123;
+        opts.customSalt = 0xabc0000000000000000000000000000000000000000000000000000000000123;
 
         bytes memory bytecodeAddressRegistrySimulator = abi.encodePacked(type(AddressRegistrySimulator).creationCode);
 

--- a/test/contracts/AddressRegistrySimulator.sol
+++ b/test/contracts/AddressRegistrySimulator.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+contract AddressRegistrySimulator is Initializable, OwnableUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address initialOwner) public initializer {
+        __Ownable_init(initialOwner);
+    }
+}


### PR DESCRIPTION
It adds support for create2 in proxy deployment.

Note, don't forget to clean before running tests. To test this [PR](https://github.com/subvisual/openzeppelin-foundry-upgrades/blob/create2-support/test/Upgrades.t.sol#L54-L79):

`forge clean && forge test --match-test testDeterministicUUPS --ffi`

